### PR TITLE
Cmems read alongtrack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 This set of files constitute the Matlab code necessary to derive altimetry proxies of Agulhas Jet and boundary transports as describe in  Beal, L. M. and S. Elipot, Broadening not strengthening of the Agulhas Current since the early 1990s, Nature, 540, 570573, http://dx.doi.org/10.1038/nature19853
 
-The first code to run is read_alongtrack.m which assembles the altimeter data; the seond code to run is transport_sla_regression_vert_102.m
+The first code to run is read_alongtrack.m which assembles the altimeter data; the second code to run is transport_sla_regression_vert_102.m
 
 The other .m Matlab files are necessary dependencies. The commercial Matlab toolboxes "signal processing" and "statistics" are necessary, as well as the freely distributed Matlab jLab toolbox written by Jonathan Lilly. Please see http://www.jmlilly.net/jmlsoft.html 
 
 **As of May 2017, this code is untested on any other system than mine**, an Apple Computer with operating system macOS Sierra Version 10.12.5 running Matlab version 9.0.0.341360 (R2016a).
 
 Feel free to contribute to this depository, otherwise please email questions or comments to selipot@rsmas.miami.edu. I will reply within a reasonable amount of time. 
+
+** August 2021: implementing reading alongtrack altimetry from CMEMS (instead of AVISO earlier) to derive the same proxy for subsequent years.

--- a/cmemcs_read_alongtrack.m
+++ b/cmemcs_read_alongtrack.m
@@ -1,7 +1,11 @@
-% code to read and assemble the downloaded AVISO along track data
+% code to read and assemble the downloaded CMEMS (AVISO) along track data
 % this code assumes you are on a UNIX-like system
 
-% this assume you have downloaded the global, delayed-time, along-track, unfiltered, absolute dynamic topography data from AVISO
+% this assume you have downloaded the global, delayed-time, along-track, unfiltered, (absolute dynamic topography data from AVISO) Sea Level Anomalies from CMEMS (https://resources.marine.copernicus.eu/?option=com_csw&view=details&product_id=SEALEVEL_GLO_PHY_L3_REP_OBSERVATIONS_008_062)
+
+% data for Jason 3 are organized by individual netcdf files with extension .nc
+% data for Jason 2 are organized in subfolders by years; individual netcdf files with extension .nc
+
 
 % data for TOPEX/Poseidon are organized in subfolders by years; individual files are zipped with extension .gz
 

--- a/cmemcs_read_alongtrack.m~
+++ b/cmemcs_read_alongtrack.m~
@@ -63,7 +63,7 @@ for year = 1993:2002
     end
     end
 end
-%    
+%%    
 % jason 1
 
 % basedir = 'aviso/global/delayed-time/along-track/unfiltered/adt/j1/';
@@ -92,7 +92,7 @@ for year = 2002:2008
                 for m = 1:length(netvar)
                     eval([netvar{m}  '= ncread([''foo.nc''],''' netvar{m} ''');']);
                 end
-                adt96_j1_vxxc(n).ADT = sla_unfiltered(q96)+mdt(q96);
+                adt96_j1_vxxc(n).ADT = ADT(q96);
                 adt96_j1_vxxc(n).cycle = cycle(q96);
                 adt96_j1_vxxc(n).latitude = latitude(q96);
                 adt96_j1_vxxc(n).longitude = longitude(q96);
@@ -101,33 +101,30 @@ for year = 2002:2008
                 adt96_j1_vxxc(n).file = filelist(k).name;
                 disp(n);
                 sprintf('%d',n);
-                clear sla_unfiltered mdt cycle latitude longitude time track q96
+                clear ADT cycle latitude longitude time track q96
             end
             eval(['!rm foo.nc']);
-    end
     end
 end
 
 
 % jason 2
 
-% basedir = 'aviso/global/delayed-time/along-track/unfiltered/adt/j2/';
-basedir = '/Users/gnovelli/Desktop/sla-cmems/j2/';
+basedir = 'aviso/global/delayed-time/along-track/unfiltered/adt/j2/';
+
 n = 0;
 
-% for year = 2008:2016;
-for year = 2008:2016
-    for month = 1:12
-        
-    filelist = dir([basedir num2str(year) '/' num2str(month,'%02d')]);
+for year = 2008:2016;
+    
+    filelist = dir([basedir num2str(year)]);
     % remove directories
     q = find([filelist.isdir] == 1);
     filelist(q) = [];
         
     for k = 1:length(filelist)
         
-            eval(['!cp ' basedir num2str(year) '/' num2str(month,'%02d') '/' filelist(k).name ' ./foo.nc']);
-%             eval(['!gunzip -f foo.nc.gz']);
+            eval(['!cp ' basedir num2str(year) '/' filelist(k).name ' ./foo.nc.gz']);
+            eval(['!gunzip -f foo.nc.gz']);
             pause(.1);
             track = ncread(['foo.nc'],'track');
             % should load ADT, cycle, latitude, longitude, time, track, all of same dimension
@@ -137,7 +134,7 @@ for year = 2008:2016
                 for m = 1:length(netvar)
                     eval([netvar{m}  '= ncread([''foo.nc''],''' netvar{m} ''');']);
                 end
-                adt96_j2_vxxc(n).ADT =  sla_unfiltered(q96)+mdt(q96);
+                adt96_j2_vxxc(n).ADT = ADT(q96);
                 adt96_j2_vxxc(n).cycle = cycle(q96);
                 adt96_j2_vxxc(n).latitude = latitude(q96);
                 adt96_j2_vxxc(n).longitude = longitude(q96);
@@ -146,55 +143,9 @@ for year = 2008:2016
                 adt96_j2_vxxc(n).file = filelist(k).name;
                 disp(n);
                 sprintf('%d',n);
-                clear sla_unfiltered mdt cycle latitude longitude time track q96
+                clear ADT cycle latitude longitude time track q96
             end
             eval(['!rm foo.nc']);
-    end
-    end
-    
-end
-%
-% jason 3
-
-% basedir = 'aviso/global/delayed-time/along-track/unfiltered/adt/j2/';
-basedir = '/Users/gnovelli/Desktop/sla-cmems/j3/';
-n = 0;
-
-
-for year = 2016:2020
-    for month = 1:12
-        
-    filelist = dir([basedir num2str(year) '/' num2str(month,'%02d')]);
-    % remove directories
-    q = find([filelist.isdir] == 1);
-    filelist(q) = [];
-        
-    for k = 1:length(filelist)
-        
-            eval(['!cp ' basedir num2str(year) '/' num2str(month,'%02d') '/' filelist(k).name ' ./foo.nc']);
-%             eval(['!gunzip -f foo.nc.gz']);
-            pause(.1);
-            track = ncread(['foo.nc'],'track');
-            % should load ADT, cycle, latitude, longitude, time, track, all of same dimension
-            q96 = find(track==96);
-            if ~isempty(q96)
-                n = n+1;
-                for m = 1:length(netvar)
-                    eval([netvar{m}  '= ncread([''foo.nc''],''' netvar{m} ''');']);
-                end
-                adt96_j3_vxxc(n).ADT =  sla_unfiltered(q96)+mdt(q96);
-                adt96_j3_vxxc(n).cycle = cycle(q96);
-                adt96_j3_vxxc(n).latitude = latitude(q96);
-                adt96_j3_vxxc(n).longitude = longitude(q96);
-                adt96_j3_vxxc(n).time = time(q96);
-                adt96_j3_vxxc(n).track = track(q96);
-                adt96_j3_vxxc(n).file = filelist(k).name;
-                disp(n);
-                sprintf('%d',n);
-                clear sla_unfiltered mdt cycle latitude longitude time track q96
-            end
-            eval(['!rm foo.nc']);
-    end
     end
     
 end
@@ -202,5 +153,4 @@ end
 save('adt96_tp.mat','adt96_tp_vxxc');
 save('adt96_j1.mat','adt96_j1_vxxc');
 save('adt96_j2.mat','adt96_j2_vxxc');
-save('adt96_j3.mat','adt96_j3_vxxc');
 

--- a/transport_sla_regression_vert_102.m~
+++ b/transport_sla_regression_vert_102.m~
@@ -50,11 +50,11 @@ dM3(8) = 0.5*(dM2(9)+dM2(10)); %P3-P4
 dM3(9) = 0.5*(dM2(10)+dM2(11)); %P3-P4
 
 % load the assembled sla data from the read_alongtrack.m code
-load('/Users/gnovelli/Desktop/sla-cmems/adt96_tp.mat','adt96_tp_vxxc');
-load('/Users/gnovelli/Desktop/sla-cmems/adt96_j1.mat','adt96_j1_vxxc');
-load('/Users/gnovelli/Desktop/sla-cmems/adt96_j2.mat','adt96_j2_vxxc');
-load('/Users/gnovelli/Desktop/sla-cmems/adt96_j3.mat','adt96_j3_vxxc');
-%
+load('adt96_tp.mat','adt96_tp_vxxc');
+load('adt96_j1.mat','adt96_j1_vxxc');
+load('adt96_j2.mat','adt96_j2_vxxc');
+load('adt96_j3.mat','adt96_j2_vxxc');
+
 % convert int16 to double
 for k = 1:length(adt96_tp_vxxc)
     adt96_tp_vxxc(k).track = double(adt96_tp_vxxc(k).track);
@@ -121,7 +121,7 @@ for k = 1:length(ncycle)
 end
 
 clear cycle_*
-clear adt96_tp_vxxc adt96_j1_vxxc adt96_j2_vxxc adt96_j3_vxxc
+clear adt96_tp_vxxc adt96_j1_vxxc adt96_j2_vxxc adt96_j2_vxxc
 clear ADT cycle latitude longitude time
 
 ncycle_adt = ncycle;


### PR DESCRIPTION
cmems_read_alongtrack works fine. the only thing is that on cmems TP data begins in 1993 instead of 1992.

However transport_sla_regression_vert_102.m does not work. I added the new data from jason 3. I get warnings and errors:

Warning: Matrix is singular, close to singular or badly scaled. Results may be inaccurate. RCOND = NaN. 
> In pvaluedw (line 62)
  In dwtest (line 100)
  In regstats (line 372)
  In transport_sla_regression_vert_102 (line 266)
 
   NaN   NaN

Error using  * 
Incorrect dimensions for matrix multiplication. Check that the number of columns in the first matrix matches
the number of rows in the second matrix. To perform elementwise multiplication, use '.*'.

Error in transport_sla_regression_vert_102 (line 279)
    xr = yr(qnan,:)*xstats2{m}.beta(2:end);
